### PR TITLE
Select encoding

### DIFF
--- a/resources/library.properties
+++ b/resources/library.properties
@@ -46,4 +46,4 @@ version = 1  # This must be parsable as an int
 
 # The version as the user will see it. If blank, the version attribute will be 
 # used here.
-prettyVersion = 0.1.1 # This is treated as a String
+prettyVersion = 0.1.2 # This is treated as a String

--- a/src/http/requests/PostRequest.java
+++ b/src/http/requests/PostRequest.java
@@ -26,11 +26,18 @@ public class PostRequest
 	HashMap<String,File> nameFilePairs;
 
 	String content;
+	String encoding;
 	HttpResponse response;
 
-	public PostRequest(String url) 
+	public PostRequest(String url)
+	{
+	  this(url, "ISO-8859-1");
+	}
+	
+	public PostRequest(String url, String encoding) 
 	{
 		this.url = url;
+		this.encoding = encoding;
 		nameValuePairs = new ArrayList<BasicNameValuePair>();
 		nameFilePairs = new HashMap<String,File>();
 	}
@@ -57,7 +64,7 @@ public class PostRequest
 			HttpPost httpPost = new HttpPost(url);
 
 			if (nameFilePairs.isEmpty()) {
-				httpPost.setEntity(new UrlEncodedFormEntity(nameValuePairs));
+				httpPost.setEntity(new UrlEncodedFormEntity(nameValuePairs, encoding));
 			} else {
 				MultipartEntity mentity = new MultipartEntity();	
 				Iterator<Entry<String,File>> it = nameFilePairs.entrySet().iterator();


### PR DESCRIPTION
# Problem
`HttpPost` seems to send a request using "ISO-8859-1" encoing.  But some API don't accept "ISO-8859-1", and need "UTF-8" insted of "ISO-8859-1".

# Solution
Pass an encode information to `PostRequest` at its constructor.

Thanks! @runemadsen 