### PR TITLE
Fixed typo in example

### DIFF
--- a/examples/jsonpost/jsonpost.pde
+++ b/examples/jsonpost/jsonpost.pde
@@ -6,7 +6,7 @@ public void setup()
   smooth();
 
   PostRequest post = new PostRequest("http://httprocessing.heroku.com");
-  put.addHeader("Content-Type", "application/json");
+  post.addHeader("Content-Type", "application/json");
   post.addData("{\"on\":false}");
   post.send();
   System.out.println("Reponse Content: " + post.getContent());


### PR DESCRIPTION
The POST example referenced a put object instead of post when adding the header, so fixed the typo.